### PR TITLE
Remove deprecated "bottle :unneeded"

### DIFF
--- a/setlx.rb
+++ b/setlx.rb
@@ -7,7 +7,6 @@ class Setlx < Formula
 
   depends_on "openjdk"
   depends_on "rlwrap"
-  bottle :unneeded
 
   def install
     system "sed", "-i", ".original", "s,setlXJarDirectory=\".\",setlXJarDirectory=\"#{prefix}/\",g", "./setlX"


### PR DESCRIPTION
"bottle :unneeded" was deprecated by Homebrew.
I removed it from the formulae (see https://github.com/Homebrew/discussions/discussions/2311#discussioncomment-1507233).
